### PR TITLE
feat(backtest): add --bench flag + capture metrics in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/entropy-lab/Entropy-Portfolio-Lab/actions/workflows/ci.yml/badge.svg)](https://github.com/entropy-lab/Entropy-Portfolio-Lab/actions/workflows/ci.yml)
+
 # Entropy Portfolio Lab
 
 A unified, research-to-execution repository for **entropy-aware portfolio trading**.
@@ -146,7 +148,26 @@ pytest backtest/tests -q
 python -m backtest.cli run --csv backtest/samples/AAPL.csv \
   --strategy backtest.strategies.flat:Flat --mode target
 
+# SMA cross (target sizing)
+python -m backtest.cli run --csv backtest/samples/AAPL.csv \
+  --strategy backtest.strategies.sma:SMACross --mode target
+
+# RSI/EMA mean reversion (delta sizing with brackets)
+python -m backtest.cli run --csv backtest/samples/AAPL.csv \
+  --strategy backtest.strategies.rsi_ema:RSIEmaMeanRevert --mode delta
+
 # portfolio example (spec file)
 echo '[{"name":"AAPL","csv":"backtest/samples/AAPL.csv","strategy":"backtest.strategies.flat:Flat","params":{}}]' > port.json
 python -m backtest.cli portfolio --spec port.json --mode target
 ```
+
+**Benchmarked runs**
+
+```bash
+python -m backtest.cli run \
+  --csv backtest/samples/AAPL.csv \
+  --strategy backtest.strategies.flat:Flat \
+  --bench backtest/samples/AAPL.csv
+```
+
+Prints Alpha, Beta, Information Ratio, Up/Down Capture, and Tracking Error (because numbers are friends).

--- a/backtest/strategies/__init__.py
+++ b/backtest/strategies/__init__.py
@@ -1,4 +1,23 @@
 """Reference strategies bundled with the backtester."""
-from .flat import Flat, Params, factory
 
-__all__ = ["Flat", "Params", "factory"]
+from .flat import Flat
+from .flat import Params as FlatParams
+from .flat import factory as flat_factory
+from .rsi_ema import Params as RSIEmaParams
+from .rsi_ema import RSIEmaMeanRevert
+from .rsi_ema import factory as rsi_ema_factory
+from .sma import Params as SMACrossParams
+from .sma import SMACross
+from .sma import factory as sma_factory
+
+__all__ = [
+    "Flat",
+    "FlatParams",
+    "flat_factory",
+    "SMACross",
+    "SMACrossParams",
+    "sma_factory",
+    "RSIEmaMeanRevert",
+    "RSIEmaParams",
+    "rsi_ema_factory",
+]

--- a/backtest/strategies/flat.py
+++ b/backtest/strategies/flat.py
@@ -1,11 +1,16 @@
 """Example strategy that never takes risk."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import pandas as pd
 
 from ..core.strategy import BarStrategy
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from ..core.broker import Broker
 
 
 @dataclass
@@ -17,7 +22,13 @@ class Flat(BarStrategy):
     def warmup(self) -> int:
         return 0
 
-    def on_bar(self, timestamp: pd.Timestamp, row: pd.Series, index: int, broker) -> int:  # type: ignore[override]
+    def on_bar(
+        self,
+        timestamp: pd.Timestamp,
+        row: pd.Series,
+        index: int,
+        broker: "Broker",
+    ) -> int:
         return 0
 
 

--- a/backtest/strategies/rsi_ema.py
+++ b/backtest/strategies/rsi_ema.py
@@ -1,0 +1,145 @@
+"""RSI/EMA mean reversion strategy with bracket exits."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, Optional
+
+import pandas as pd
+
+from ..core.brackets import BracketOrder, BracketState
+from ..core.indicators import ema, rsi
+from ..core.strategy import BarStrategy
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from ..core.broker import Broker
+
+
+@dataclass
+class Params:
+    rsi_length: int = 14
+    ema_length: int = 50
+    lower: float = 35.0
+    upper: float = 65.0
+    stop_pct: float = 0.01
+    target_pct: float = 0.02
+    trailing_pct: Optional[float] = None
+
+    @classmethod
+    def from_dict(cls, params: Optional[Dict[str, float]]) -> "Params":
+        base = cls()
+        if not params:
+            return base
+        data = {
+            "rsi_length": base.rsi_length,
+            "ema_length": base.ema_length,
+            "lower": base.lower,
+            "upper": base.upper,
+            "stop_pct": base.stop_pct,
+            "target_pct": base.target_pct,
+            "trailing_pct": base.trailing_pct,
+        }
+        for key in data:
+            if key in params and params[key] is not None:
+                value = params[key]
+                if key in {"rsi_length", "ema_length"}:
+                    data[key] = int(value)
+                elif key == "trailing_pct":
+                    data[key] = float(value)
+                else:
+                    data[key] = float(value)
+        return cls(**data)
+
+
+class RSIEmaMeanRevert(BarStrategy):
+    """Fade RSI extremes back toward the EMA using bracket exits."""
+
+    def __init__(self, params: Optional[Dict[str, float]] = None) -> None:
+        super().__init__(params)
+        self.config = Params.from_dict(params)
+        if self.config.rsi_length <= 0 or self.config.ema_length <= 0:
+            raise ValueError("Indicator lengths must be positive integers")
+
+        stop_pct = (
+            self.config.stop_pct
+            if self.config.stop_pct and self.config.stop_pct > 0
+            else None
+        )
+        target_pct = (
+            self.config.target_pct
+            if self.config.target_pct and self.config.target_pct > 0
+            else None
+        )
+        trailing_pct = (
+            self.config.trailing_pct
+            if self.config.trailing_pct and self.config.trailing_pct > 0
+            else None
+        )
+
+        self._bracket_template = BracketOrder(
+            stop_pct=stop_pct,
+            target_pct=target_pct,
+            trailing_pct=trailing_pct,
+        )
+        self._bracket_state: Optional[BracketState] = None
+        self._ema: Optional[pd.Series] = None
+        self._rsi: Optional[pd.Series] = None
+
+    def bind(self, data: pd.DataFrame) -> None:
+        super().bind(data)
+        frame = self.data
+        close = frame["close"]
+        self._ema = ema(close, self.config.ema_length)
+        self._rsi = rsi(close, self.config.rsi_length)
+
+    def warmup(self) -> int:
+        return int(max(self.config.rsi_length, self.config.ema_length))
+
+    def _reset_bracket(self) -> None:
+        self._bracket_state = None
+
+    def _open_bracket(self, side: int, price: float) -> None:
+        self._bracket_state = self._bracket_template.initial_levels(side, price)
+
+    def on_bar(
+        self,
+        timestamp: pd.Timestamp,
+        row: pd.Series,
+        index: int,
+        broker: "Broker",
+    ) -> int:
+        if self._ema is None or self._rsi is None:
+            raise RuntimeError("Strategy is not bound to data")
+
+        ema_value = self._ema.iloc[index]
+        rsi_value = self._rsi.iloc[index]
+        if pd.isna(ema_value) or pd.isna(rsi_value):
+            return 0
+
+        close_price = float(row["close"])
+        position = int(round(broker.position))
+
+        if position == 0:
+            self._reset_bracket()
+            if close_price < float(ema_value) and float(rsi_value) < self.config.lower:
+                self._open_bracket(1, close_price)
+                return 1
+            if close_price > float(ema_value) and float(rsi_value) > self.config.upper:
+                self._open_bracket(-1, close_price)
+                return -1
+        else:
+            if self._bracket_state is not None:
+                exit_reason = self._bracket_state.update(row)
+                if exit_reason:
+                    qty = -position
+                    self._reset_bracket()
+                    return qty
+
+        return 0
+
+
+def factory(params: Optional[Dict[str, float]]) -> RSIEmaMeanRevert:
+    return RSIEmaMeanRevert(params)
+
+
+__all__ = ["RSIEmaMeanRevert", "Params", "factory"]

--- a/backtest/strategies/sma.py
+++ b/backtest/strategies/sma.py
@@ -1,0 +1,77 @@
+"""Simple moving average cross strategy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, Optional
+
+import pandas as pd
+
+from ..core.indicators import sma
+from ..core.strategy import BarStrategy
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from ..core.broker import Broker
+
+
+@dataclass
+class Params:
+    fast: int = 10
+    slow: int = 30
+
+    @classmethod
+    def from_dict(cls, params: Optional[Dict[str, int]]) -> "Params":
+        base = cls()
+        if not params:
+            return base
+        data = {"fast": base.fast, "slow": base.slow}
+        for key in ("fast", "slow"):
+            if key in params and params[key] is not None:
+                data[key] = int(params[key])
+        return cls(**data)
+
+
+class SMACross(BarStrategy):
+    """Go long when the fast SMA is above the slow SMA."""
+
+    def __init__(self, params: Optional[Dict[str, int]] = None) -> None:
+        super().__init__(params)
+        self.config = Params.from_dict(params)
+        if self.config.fast <= 0 or self.config.slow <= 0:
+            raise ValueError("SMA lengths must be positive integers")
+        self._fast_series: Optional[pd.Series] = None
+        self._slow_series: Optional[pd.Series] = None
+
+    def bind(self, data: pd.DataFrame) -> None:
+        super().bind(data)
+        frame = self.data
+        close = frame["close"]
+        self._fast_series = sma(close, self.config.fast)
+        self._slow_series = sma(close, self.config.slow)
+
+    def warmup(self) -> int:
+        return int(max(self.config.fast, self.config.slow))
+
+    def on_bar(
+        self,
+        timestamp: pd.Timestamp,
+        row: pd.Series,
+        index: int,
+        broker: "Broker",
+    ) -> int:
+        if self._fast_series is None or self._slow_series is None:
+            raise RuntimeError("Strategy is not bound to data")
+
+        fast = self._fast_series.iloc[index]
+        slow = self._slow_series.iloc[index]
+        if pd.isna(fast) or pd.isna(slow):
+            return 0
+
+        return 1 if float(fast) > float(slow) else 0
+
+
+def factory(params: Optional[Dict[str, int]]) -> SMACross:
+    return SMACross(params)
+
+
+__all__ = ["SMACross", "Params", "factory"]

--- a/backtest/tests/test_metrics.py
+++ b/backtest/tests/test_metrics.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pandas as pd
+
+from backtest.core.metrics import summarize
+
+
+def test_summarize_benchmark_metrics():
+    idx = pd.date_range("2024-01-01", periods=5, freq="D")
+    equity = pd.Series([100.0, 105.0, 100.0, 102.0, 101.0], index=idx)
+    bench = equity.copy()
+
+    stats = summarize(equity, bench=bench)
+
+    assert stats["Beta"] == 1.0
+    assert abs(stats["Alpha"]) < 1e-12
+    assert stats["TrackingError"] == 0.0
+    assert np.isnan(stats["InformationRatio"])
+    assert stats["UpCapture"] == 1.0
+    assert stats["DownCapture"] == 1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203, W503


### PR DESCRIPTION
## Summary
- add a CLI `--bench` option that feeds price data into `summarize` and surface the workflow in the README
- extend the benchmark-aware metrics set to include tracking error plus up/down capture ratios
- provide SMA cross and RSI/EMA reference strategies (wired into the package exports) with a regression test for benchmark stats

## Testing
- python -m flake8
- pytest backtest/tests -q
- python -m backtest.cli run --csv backtest/samples/AAPL.csv --strategy backtest.strategies.flat:Flat --mode target --bench backtest/samples/AAPL.csv
- python -m backtest.cli portfolio --spec port.json --mode target
- python -m backtest.cli run --csv backtest/samples/AAPL.csv --strategy backtest.strategies.sma:SMACross --mode target
- python -m backtest.cli run --csv backtest/samples/AAPL.csv --strategy backtest.strategies.rsi_ema:RSIEmaMeanRevert --mode delta

------
https://chatgpt.com/codex/tasks/task_e_68d21014404883209231f782747b9d2f