### PR TITLE
Add benchmark-aware reporting and CLI tooling

### DIFF
--- a/backtest/attribution.py
+++ b/backtest/attribution.py
@@ -27,6 +27,7 @@ __all__ = [
     "pivot_attribution",
     "percent_contributions",
     "summarize_attribution",
+    "plot_attribution",
 ]
 
 
@@ -115,3 +116,22 @@ def summarize_attribution(df: pd.DataFrame) -> dict:
         "top_asset": None if by_asset.empty else by_asset.index[0],
         "top_regime": None if by_regime.empty else by_regime.index[0],
     }
+
+
+def plot_attribution(df: pd.DataFrame, ax=None):
+    """Render a stacked bar chart of attribution by regime and asset."""
+
+    if df.empty:
+        raise ValueError("Attribution dataframe is empty")
+
+    import matplotlib.pyplot as plt
+
+    pivot = pivot_attribution(df)
+    if pivot.empty:
+        raise ValueError("Attribution pivot is empty")
+
+    axis = ax or plt.gca()
+    pivot.T.plot(kind="bar", stacked=True, ax=axis, title="PnL by Regime (stacked by asset)")
+    axis.set_ylabel("PnL")
+    axis.set_xlabel("Regime")
+    return axis

--- a/backtest/tests/test_metrics.py
+++ b/backtest/tests/test_metrics.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from backtest.core.metrics import summarize
 
@@ -15,5 +16,5 @@ def test_summarize_benchmark_metrics():
     assert abs(stats["Alpha"]) < 1e-12
     assert stats["TrackingError"] == 0.0
     assert np.isnan(stats["InformationRatio"])
-    assert stats["UpCapture"] == 1.0
-    assert stats["DownCapture"] == 1.0
+    assert stats["UpCapture"] == pytest.approx(1.0)
+    assert stats["DownCapture"] == pytest.approx(1.0)

--- a/docs/phase2.md
+++ b/docs/phase2.md
@@ -2,6 +2,19 @@
 
 ## CLI Commands
 
+### Single Strategy
+
+```bash
+python -m backtest.cli run --csv backtest/samples/AAPL.csv \
+  --strategy backtest.strategies.flat:Flat \
+  --bench backtest/samples/SPY.csv \
+  --out-daily daily.csv
+```
+
+Adding a benchmark unlocks Alpha/Beta/Information Ratio alongside the up/down
+capture figures, while `--out-daily` writes a CSV with equity, returns,
+drawdown and rolling Sharpe for quick inspection.
+
 ### Grid Search
 
 ```bash
@@ -9,6 +22,9 @@ python -m backtest.cli opt --csv backtest/samples/AAPL.csv \
   --strategy backtest.strategies.flat:Flat \
   --grid foo=1,2 bar=a,b
 ```
+
+Include `--bench backtest/samples/SPY.csv` to score candidate parameter sets on
+active statistics such as Information Ratio.
 
 ### Walk-Forward (anchored)
 
@@ -18,6 +34,9 @@ python -m backtest.cli walk --csv backtest/samples/AAPL.csv \
   --grid x=1,2 --train-years 1 --test-years 1
 ```
 
+Benchmarks propagate through walk-forward reporting as well, so mix in the same
+`--bench` flag when you want the summaries to be market-aware.
+
 ### Performance Attribution
 
 ```bash
@@ -26,6 +45,14 @@ python -m backtest.cli attr --trades forwardtest/LOG.trades.csv
 
 Provide a regimes CSV with `--regimes` to split contributions by entropy state or
 other overlays.
+
+```bash
+python -m backtest.cli attr --trades forwardtest/LOG.trades.csv \
+  --plot attribution.png
+```
+
+The optional `--plot` flag produces a stacked bar PNG showing how each asset
+contributed across regimes.
 
 ## Proof Capsules
 


### PR DESCRIPTION
## Summary
- add daily return helpers and active benchmark statistics to the metrics module so summaries capture alpha/beta, tracking error, and capture ratios
- wire benchmark loading, deterministic seeding, optional daily equity exports, and attribution plotting through the CLI (run/portfolio/opt/walk/attr)
- harden portfolio ingestion by skipping bad data and note the new CLI affordances in the Phase 2 documentation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d25336a8bc8320a9294630987aae1a