### PR TITLE
Add demo data placeholders and UI mock server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,6 @@ jobs:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
       - run: pip install pandas numpy matplotlib pytest
+      - name: Validate CSV placeholders
+        run: python data/fetch_data.py
       - run: pytest -q

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,0 +1,52 @@
+name: UI / ui
+on:
+  push: { branches: [ main, master ] }
+  pull_request: {}
+defaults:
+  run:
+    working-directory: ui
+jobs:
+  ui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node 20 (no cache if no lockfile)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install deps (auto–detect PM)
+        shell: bash
+        run: |
+          if [ ! -d "." ]; then echo "ui/ directory missing"; exit 1; fi
+          if [ -f pnpm-lock.yaml ]; then
+            corepack enable
+            pnpm i --frozen-lockfile
+          elif [ -f yarn.lock ]; then
+            corepack enable
+            yarn install --frozen-lockfile
+          elif [ -f package-lock.json ]; then
+            npm ci
+          else
+            echo "No lockfile found; using npm install (no cache)." >&2
+            npm install
+          fi
+
+      - name: Typecheck & Lint (best-effort)
+        run: |
+          npm run typecheck --if-present || true
+          npm run lint --if-present      || true
+
+      - name: Unit tests
+        run: npm test --if-present -- --run
+
+      - name: Build
+        run: npm run build --if-present
+
+      - name: Archive build (if produced)
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-dist
+          path: ui/dist
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,16 @@ obj/
 # Notebooks & data
 *.ipynb_checkpoints/
 data/
+!data/
+!data/fetch_data.py
+!data/SPY.csv
+!data/QQQ.csv
+!data/TLT.csv
+!data/GLD.csv
+!data/UUP.csv
+!data/USO.csv
+!data/UNG.csv
+!data/HYG.csv
+!data/CL_cont.csv
+!data/NG_cont.csv
+!data/HG_cont.csv

--- a/README.md
+++ b/README.md
@@ -176,3 +176,17 @@ Prints Alpha, Beta, Information Ratio, Up/Down Capture, and Tracking Error (beca
 ## Phase 2 — Advanced Analysis
 See [docs/phase2.md](docs/phase2.md) for optimization, walk-forward, attribution, and proof capsules.
 
+
+### Demo data & UI
+
+- Placeholder CSVs live in `data/*.csv` (header only). CI validates their schema.
+- Run the mock API/WS locally:
+  ```bash
+  cd tools/mock-server && npm i && npm start
+  ```
+- UI expects:
+  ```
+  VITE_API_URL=http://localhost:8787
+  VITE_WS_URL=ws://localhost:8787
+  ```
+- Copy `ui/.env.example` → `ui/.env` and adjust as needed.

--- a/data/CL_cont.csv
+++ b/data/CL_cont.csv
@@ -1,0 +1,1 @@
+datetime,open,high,low,close,volume

--- a/data/GLD.csv
+++ b/data/GLD.csv
@@ -1,0 +1,1 @@
+datetime,open,high,low,close,volume

--- a/data/HG_cont.csv
+++ b/data/HG_cont.csv
@@ -1,0 +1,1 @@
+datetime,open,high,low,close,volume

--- a/data/HYG.csv
+++ b/data/HYG.csv
@@ -1,0 +1,1 @@
+datetime,open,high,low,close,volume

--- a/data/NG_cont.csv
+++ b/data/NG_cont.csv
@@ -1,0 +1,1 @@
+datetime,open,high,low,close,volume

--- a/data/QQQ.csv
+++ b/data/QQQ.csv
@@ -1,0 +1,1 @@
+datetime,open,high,low,close,volume

--- a/data/SPY.csv
+++ b/data/SPY.csv
@@ -1,0 +1,1 @@
+datetime,open,high,low,close,volume

--- a/data/TLT.csv
+++ b/data/TLT.csv
@@ -1,0 +1,1 @@
+datetime,open,high,low,close,volume

--- a/data/UNG.csv
+++ b/data/UNG.csv
@@ -1,0 +1,1 @@
+datetime,open,high,low,close,volume

--- a/data/USO.csv
+++ b/data/USO.csv
@@ -1,0 +1,1 @@
+datetime,open,high,low,close,volume

--- a/data/UUP.csv
+++ b/data/UUP.csv
@@ -1,0 +1,1 @@
+datetime,open,high,low,close,volume

--- a/data/fetch_data.py
+++ b/data/fetch_data.py
@@ -1,0 +1,26 @@
+import os
+import pandas as pd
+
+HERE = os.path.dirname(__file__)
+EXPECTED = ["datetime", "open", "high", "low", "close", "volume"]
+
+def validate_csv(path: str):
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"CSV missing: {path}")
+    df = pd.read_csv(path, nrows=2)
+    missing = [c for c in EXPECTED if c not in df.columns]
+    if missing:
+        raise ValueError(f"{os.path.basename(path)} missing columns: {missing}")
+
+def main():
+    for f in sorted(os.listdir(HERE)):
+        if f.endswith(".csv"):
+            try:
+                validate_csv(os.path.join(HERE, f))
+                print(f"✅ {f} OK")
+            except Exception as e:
+                print(f"❌ {f}: {e}")
+                raise
+
+if __name__ == "__main__":
+    main()

--- a/port.json
+++ b/port.json
@@ -1,21 +1,10 @@
 [
-  {
-    "name": "AAPL",
-    "csv": "backtest/samples/AAPL.csv",
-    "strategy": "backtest.strategies.rsi_ema:RSIEmaMeanRevert",
-    "params": {
-      "rsi_length": 14,
-      "ema_length": 50,
-      "lower": 30,
-      "upper": 70
-    },
-    "mode": "delta",
-    "size_notional": 10000,
-    "risk_R": 1.0,
-    "atr_len": 14,
-    "risk_pct": 0.01,
-    "commission": 0.0,
-    "slippage": 0.0,
-    "expect_ohlc": true
-  }
+  {"name":"SPY","csv":"data/SPY.csv","strategy":"backtest.strategies.sma:SMACross","params":{"fast":10,"slow":40}},
+  {"name":"QQQ","csv":"data/QQQ.csv","strategy":"backtest.strategies.sma:SMACross","params":{"fast":10,"slow":40}},
+  {"name":"TLT","csv":"data/TLT.csv","strategy":"backtest.strategies.rsi_ema:RSIEmaMeanRevert","params":{"rsi_len":14,"ema_len":50}},
+  {"name":"GLD","csv":"data/GLD.csv","strategy":"backtest.strategies.rsi_ema:RSIEmaMeanRevert","params":{"rsi_len":14,"ema_len":50}},
+  {"name":"UUP","csv":"data/UUP.csv","strategy":"backtest.strategies.sma:SMACross","params":{"fast":20,"slow":80}},
+  {"name":"USO","csv":"data/USO.csv","strategy":"backtest.strategies.rsi_ema:RSIEmaMeanRevert","params":{"rsi_len":10,"ema_len":30}},
+  {"name":"UNG","csv":"data/UNG.csv","strategy":"backtest.strategies.rsi_ema:RSIEmaMeanRevert","params":{"rsi_len":10,"ema_len":30}},
+  {"name":"HYG","csv":"data/HYG.csv","strategy":"backtest.strategies.sma:SMACross","params":{"fast":20,"slow":80}}
 ]

--- a/tools/mock-server/package.json
+++ b/tools/mock-server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "mock-api-ws",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "ws": "^8.18.0",
+    "cors": "^2.8.5"
+  }
+}

--- a/tools/mock-server/server.mjs
+++ b/tools/mock-server/server.mjs
@@ -1,0 +1,55 @@
+import express from "express";
+import cors from "cors";
+import { WebSocketServer } from "ws";
+
+const PORT = process.env.PORT || 8787;
+const app = express();
+app.use(cors());
+
+/** REST: minimal backtest listings + details */
+const runs = [
+  { id: "bt_001", strategy: "SMACross", sharpe: 0.9, mdd: -0.12, when: Date.now() - 86400000 },
+  { id: "bt_002", strategy: "RSI/EMA MR", sharpe: 1.3, mdd: -0.09, when: Date.now() - 43200000 }
+];
+
+app.get("/api/backtests", (_req, res) => res.json(runs));
+app.get("/api/backtests/:id/results", (req, res) => {
+  const id = req.params.id;
+  // tiny equity stub
+  const now = Date.now();
+  const equity = Array.from({ length: 50 }, (_, i) => ({
+    t: now - (50 - i) * 3600_000,
+    v: 100000 * (1 + 0.001 * i + 0.02 * Math.sin(i / 10))
+  }));
+  res.json({ id, equity, metrics: { Sharpe: 1.1, MaxDD: -0.1 } });
+});
+app.get("/api/proofs/:id", (req, res) => {
+  res.json({ id: req.params.id, claim: "Sharpe >= 1.0", status: "green", sha: "deadbeef" });
+});
+
+const server = app.listen(PORT, () => console.log(`REST on :${PORT}`));
+
+/** WS: periodic “capsules” */
+const wss = new WebSocketServer({ server });
+wss.on("connection", ws => {
+  ws.send(JSON.stringify({ type: "hello", version: 1 }));
+  const iv = setInterval(() => {
+    const now = Date.now();
+    const payload = {
+      type: "capsule",
+      version: 1,
+      capsule_id: `cap_${now}`,
+      timestamp: now,
+      metrics: {
+        entropy: Math.random(),
+        risk: 0.5 + 0.1 * Math.sin(now / 5000),
+        pl: (Math.random() - 0.5) * 100
+      },
+      annotations: { regime: Math.random() > 0.5 ? "P" : "NP" }
+    };
+    try { ws.send(JSON.stringify(payload)); } catch {}
+  }, 1000);
+  ws.on("close", () => clearInterval(iv));
+});
+
+process.on("SIGINT", () => { server.close(); process.exit(0); });

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:8787
+VITE_WS_URL=ws://localhost:8787


### PR DESCRIPTION
## Summary
- add header-only CSV placeholders with a validation script and wire the check into Python CI
- ship a mock REST/WebSocket server, UI workflow, and example environment settings for local demos
- refresh the default portfolio spec and README to reference the demo data setup

## Testing
- python data/fetch_data.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d26b839ff4832083367fb97f34a9fc