### PR TITLE
Add architecture and lifecycle diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This lab ties together:
 
 > Goal: keep research and live execution aligned via shared specifications and metrics.
 
+See **[docs/system_diagram.md](docs/system_diagram.md)** for architecture and flow diagrams.
+
 ---
 
 ## Quick Start (Python / Research)


### PR DESCRIPTION
## Summary
- add a Mermaid-based system diagram covering architecture, lifecycle notes, and quick links for contributors
- link the new documentation from the README intro so the diagrams are easy to find

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d2786ebab883208e8bebc644e6476e