### PR TITLE
Configure mermaid CLI to use Puppeteer no-sandbox flags

### DIFF
--- a/.github/workflows/docs-diagrams.yml
+++ b/.github/workflows/docs-diagrams.yml
@@ -21,8 +21,8 @@ jobs:
           i=0
           for f in xx*; do
             outp="docs/assets/diagram_$i"
-            mmdc -i "$f" -o "${outp}.png" -b transparent
-            mmdc -i "$f" -o "${outp}.svg" -b transparent
+            mmdc -i "$f" -o "${outp}.png" -b transparent -p .puppeteer.cjs
+            mmdc -i "$f" -o "${outp}.svg" -b transparent -p .puppeteer.cjs
             i=$((i+1))
           done
       - name: Upload diagram artifacts

--- a/.puppeteer.cjs
+++ b/.puppeteer.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  headless: 'new',
+  args: [
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+    '--disable-dev-shm-usage',
+    '--disable-gpu',
+  ],
+};


### PR DESCRIPTION
## Summary
- add a shared Puppeteer configuration so headless Chromium can run without sandboxing in CI
- update the docs-diagrams workflow to render Mermaid diagrams with the new configuration

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d282dadf348320bb2f36824d11740b