### PR TITLE
Install Chromium deps for docs diagrams workflow

### DIFF
--- a/.github/workflows/docs-diagrams.yml
+++ b/.github/workflows/docs-diagrams.yml
@@ -9,6 +9,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+      - name: Install Chromium runtime deps (for Puppeteer)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libasound2 libatk1.0-0 libatk-bridge2.0-0 libcairo2 libcups2 \
+            libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgtk-3-0 \
+            libnspr4 libnss3 libpango-1.0-0 libx11-6 libx11-xcb1 libxcb1 \
+            libxcomposite1 libxdamage1 libxext6 libxfixes3 libxrandr2 \
+            libxshmfence1 libxss1 ca-certificates fonts-liberation
       - name: Install mermaid-cli
         run: npm i -g @mermaid-js/mermaid-cli@10.9.0
       - name: Render Mermaid blocks from docs/system_diagram.md


### PR DESCRIPTION
## Summary
- install required Chromium runtime libraries on the docs-diagrams workflow before running mermaid-cli

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d288549c788320a3cd7a94f5d9cba4