### PR TITLE
Update Chromium runtime dependency package

### DIFF
--- a/.github/workflows/docs-diagrams.yml
+++ b/.github/workflows/docs-diagrams.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libasound2 libatk1.0-0 libatk-bridge2.0-0 libcairo2 libcups2 \
+            libasound2t64 libatk1.0-0 libatk-bridge2.0-0 libcairo2 libcups2 \
             libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgtk-3-0 \
             libnspr4 libnss3 libpango-1.0-0 libx11-6 libx11-xcb1 libxcb1 \
             libxcomposite1 libxdamage1 libxext6 libxfixes3 libxrandr2 \


### PR DESCRIPTION
## Summary
- replace libasound2 with libasound2t64 in the docs-diagrams workflow to keep Puppeteer dependencies up to date

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d2f440eb448320b1bb57c5341a3df5