### PR TITLE
Update Puppeteer dependencies for Ubuntu 24.04

### DIFF
--- a/.github/workflows/docs-diagrams.yml
+++ b/.github/workflows/docs-diagrams.yml
@@ -12,12 +12,22 @@ jobs:
       - name: Install Chromium runtime deps (for Puppeteer)
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            libasound2t64 libatk1.0-0 libatk-bridge2.0-0 libcairo2 libcups2 \
-            libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgtk-3-0 \
-            libnspr4 libnss3 libpango-1.0-0 libx11-6 libx11-xcb1 libxcb1 \
-            libxcomposite1 libxdamage1 libxext6 libxfixes3 libxrandr2 \
-            libxshmfence1 libxss1 ca-certificates fonts-liberation
+          sudo apt-get install -y --no-install-recommends \
+            libasound2t64 \
+            libatk1.0-0 \
+            libatk-bridge2.0-0 \
+            libcups2 \
+            libdrm2 \
+            libgbm1 \
+            libgtk-3-0 \
+            libnspr4 \
+            libnss3 \
+            libx11-xcb1 \
+            libxcomposite1 \
+            libxdamage1 \
+            libxfixes3 \
+            libxrandr2 \
+            xdg-utils
       - name: Install mermaid-cli
         run: npm i -g @mermaid-js/mermaid-cli@10.9.0
       - name: Render Mermaid blocks from docs/system_diagram.md


### PR DESCRIPTION
## Summary
- update the docs-diagrams workflow to install libasound2t64 for Ubuntu 24.04
- trim the Chromium dependency list to the minimal set provided and disable recommends

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2f640dfc88320b0302f2c059938a2