### PR TITLE
Fix Mermaid CLI invocation for CI

### DIFF
--- a/docs/system_diagram.md
+++ b/docs/system_diagram.md
@@ -14,7 +14,8 @@ flowchart LR
 
     subgraph Backtest["Python: Backtesting & Analytics"]
       Engine[Engine\n(brackets, sizing, walk-forward)] --- Portfolio[Portfolio Runner]
-      Metrics[Metrics Suite\nSharpe/Sortino/Calmar/Martin/Omega/\nVaR/CVaR/Alpha/Beta/IR/Ulcer/Time-in-Mkt/Turnover] --- Attribution[Attribution]
+      Metrics[Metrics Suite\nSharpe/Sortino/Calmar/Martin/Omega/\nVaR/CVaR/Alpha/Beta/IR/Ulcer/Time-in-Mkt/Turnover] --- Attribution
+      Attribution[Attribution]
       Optimize[Grid Search\n+ Sensitivity] --- WalkFwd[Anchored Walk-Forward\n+ Monte Carlo]:::dim
       Engine --> Metrics --> Attribution
       Engine --> Optimize --> WalkFwd


### PR DESCRIPTION
## Summary
- invoke Mermaid CLI through `npx` with explicit no-sandbox Puppeteer configuration to avoid Chromium launch failures in CI
- rewrite the extraction step to emit one `.mmd` file per fenced block so that each diagram renders independently
- adjust the architecture diagram so the Attribution node uses valid Mermaid syntax

## Testing
- `bash .github/scripts/render_mermaid.sh docs/system_diagram.md` *(fails locally: missing libatk shared library in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d30cf80b3483208e3f4b82ab21d483