### PR TITLE
Adjust UI workflow node setup

### DIFF
--- a/.github/workflows/ci-ui.yml
+++ b/.github/workflows/ci-ui.yml
@@ -20,11 +20,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
+      # If we have at least one lockfile anywhere in the repo, enable npm cache.
+      - name: Setup Node (with cache)
+        if: ${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') != '' }}
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            tools/mock-server/package-lock.json
+            ui/package-lock.json
+
+      # Otherwise, fall back to plain setup (no cache), which avoids the hard error.
+      - name: Setup Node (no cache)
+        if: ${{ hashFiles('**/package-lock.json', '**/npm-shrinkwrap.json', '**/yarn.lock') == '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: Install root tools (wait-on, concurrently)
         run: |
@@ -33,7 +46,7 @@ jobs:
       # --- Mock server ------------------------------------------------------
       - name: Install mock-server deps
         working-directory: tools/mock-server
-        run: npm ci
+        run: npm ci || npm i
 
       - name: Start mock server (background)
         working-directory: tools/mock-server
@@ -43,7 +56,7 @@ jobs:
       # --- UI build + preview ----------------------------------------------
       - name: Install UI deps
         working-directory: ui
-        run: npm ci
+        run: npm ci || npm i
 
       - name: Build UI
         working-directory: ui


### PR DESCRIPTION
## Summary
- add conditional Node setup steps to only configure caching when lockfiles exist
- allow npm install steps to fall back to `npm i` when lockfiles are absent

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d34099fd288320bcf2a588105bf780