### PR TITLE
Add walk-forward CLI command and deterministic smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,23 @@ jobs:
         with:
           python-version: '3.11'
       - run: python -m pip install --upgrade pip
-      - run: pip install pandas numpy matplotlib pytest
+      - run: pip install -r requirements.txt
       - name: Validate CSV placeholders
         run: python data/fetch_data.py
       - run: pytest -q
+      - name: Walk-forward smoke (deterministic)
+        run: |
+          python -m backtest.cli wf \
+            --csv data/sample_multi_asset_data.csv \
+            --strategy sma_cross \
+            --params '{"fast":10,"slow":30}' \
+            --train-years 0.05 --test-months 0.5 --step-months 0.5 \
+            --seed 42 \
+            --out-json wf_ci.json
+          test -f wf_ci.json
+          python - <<'PY'
+          import json
+          report = json.load(open('wf_ci.json'))
+          assert report['fold_count'] > 0, 'walk-forward produced no folds'
+          print('wf aggregate:', report['aggregate'])
+          PY

--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ python -m backtest.cli run \
   --out-csv artifacts/equity.csv
 ```
 
+### Walk-forward (expanding train → OOS test)
+
+```bash
+python -m backtest.cli wf \
+  --csv data/sample_multi_asset_data.csv \
+  --strategy sma_cross \
+  --params '{"fast": 10, "slow": 30}' \
+  --train-years 0.05 --test-months 0.5 --step-months 0.5 \
+  --seed 42 \
+  --out-json wf_report.json
+```
+
+The command writes `wf_report.json` with per-fold metrics and an aggregate block.
+Use this in CI to guard regressions without leaking future data. The sample
+dataset is only a few dozen rows, so the window sizes above are intentionally
+small—bump them up for real research data.
+
 > Goal: keep research and live execution aligned via shared specifications and metrics.
 
 See **[docs/system_diagram.md](docs/system_diagram.md)** for architecture and flow diagrams.

--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -1,6 +1,14 @@
+import json
+from pathlib import Path
+from typing import Callable, Dict, Iterable
+
 import click
+import pandas as pd
+
+from backtest.walkforward import walk_forward as walk_forward_report
+from backtest.strategies import flat_factory, rsi_ema_factory, sma_factory
 from engines.multi_asset_backtest import run_backtest
-from engines.optimize import grid_search, walk_forward
+from engines.optimize import grid_search, walk_forward as anchored_walk_forward
 
 
 @click.group()
@@ -34,7 +42,88 @@ def opt_cmd(**kw):
 @click.option("--grid", required=True)
 @click.option("--out-csv", default="wf.csv")
 def walk_cmd(**kw):
-    walk_forward(**kw)
+    anchored_walk_forward(**kw)
+
+
+def _resolve_strategy_factory(name: str) -> Callable[[Dict[str, object]], object]:
+    mapping = {
+        "flat": flat_factory,
+        "sma_cross": sma_factory,
+        "sma": sma_factory,
+        "rsi_ema": rsi_ema_factory,
+        "rsi_ema_mean_revert": rsi_ema_factory,
+    }
+    key = name.replace("-", "_").lower()
+    if key not in mapping:
+        raise click.ClickException(f"Unknown strategy: {name}")
+    return mapping[key]
+
+
+def _parse_params(raw: str) -> Dict[str, object]:
+    text = (raw or "").strip()
+    if not text:
+        return {}
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise click.ClickException(f"Invalid JSON for --params: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise click.ClickException("--params must decode to a JSON object")
+    return parsed
+
+
+def _load_csv(path: str) -> pd.DataFrame:
+    csv_path = Path(path)
+    if not csv_path.exists():
+        raise click.ClickException(f"CSV not found: {csv_path}")
+    return pd.read_csv(csv_path)
+
+
+def _prepare_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    df = frame.copy()
+    lower_map = {col: col.lower() for col in df.columns}
+    if "close" not in lower_map.values():
+        close_candidates: Iterable[str] = [
+            col for col in df.columns if col.lower().endswith("_close")
+        ]
+        if close_candidates:
+            df["close"] = df[close_candidates].astype(float).mean(axis=1)
+    else:
+        for column, lowered in lower_map.items():
+            if lowered == "close" and column != "close":
+                df = df.rename(columns={column: "close"})
+                break
+    return df
+
+
+@cli.command("wf")
+@click.option("--csv", "csv_path", required=True, help="Path to input CSV")
+@click.option("--strategy", required=True, help="Strategy name (e.g., sma_cross)")
+@click.option("--params", default="{}", help="JSON dictionary of strategy parameters")
+@click.option("--train-years", type=float, default=2.0)
+@click.option("--test-months", type=float, default=3.0)
+@click.option("--step-months", type=float, default=3.0)
+@click.option("--seed", type=int, default=42)
+@click.option("--out-json", default="wf_report.json")
+def wf_cmd(csv_path, strategy, params, train_years, test_months, step_months, seed, out_json):
+    frame = _prepare_frame(_load_csv(csv_path))
+    factory = _resolve_strategy_factory(strategy)
+    params_dict = _parse_params(params)
+
+    report = walk_forward_report(
+        frame,
+        make_strategy=factory,
+        params=params_dict,
+        train_years=train_years,
+        test_months=test_months,
+        step_months=step_months,
+        seed=seed,
+    )
+
+    out_path = Path(out_json)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(report, indent=2, sort_keys=True))
+    click.echo(f"[wf] wrote {out_path} with {report['fold_count']} folds")
 
 
 if __name__ == "__main__":

--- a/backtest/tests/test_walkforward.py
+++ b/backtest/tests/test_walkforward.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
+
+import numpy as np
 import pandas as pd
 
-from backtest.walkforward import anchored_walk_forward
+from backtest.walkforward import anchored_walk_forward, walk_forward
 from backtest.strategies.flat import Flat
 
 
@@ -25,3 +28,51 @@ def test_walkforward_flat_strategy_has_flat_oos_returns():
         assert abs(split.oos_stats.get("TotalReturn", 0.0)) < 1e-9
         assert abs(split.oos_stats.get("CAGR", 0.0)) < 1e-9
         assert split.oos_stats.get("Trades", 0.0) == 0.0
+
+
+class _DummyResult:
+    def __init__(self, index: pd.Index) -> None:
+        self.equity_curve = pd.Series(np.linspace(1.0, 1.1, len(index)), index=index)
+        self.fills = pd.DataFrame(columns=["timestamp", "symbol", "qty", "price"]).set_index(
+            pd.Index([], name="timestamp")
+        )
+        self.trade_log = pd.DataFrame()
+
+
+def _run_backtest_stub(frame: pd.DataFrame, strategy, seed: int | None = None, **_):
+    if seed is not None:
+        np.random.seed(seed)
+    return _DummyResult(frame.index)
+
+
+def _metric_stub(result: _DummyResult):
+    eq = result.equity_curve
+    ret = float(eq.iloc[-1] / eq.iloc[0] - 1.0) if len(eq) > 1 else 0.0
+    return {"return": ret}
+
+
+def test_simple_walkforward_report_is_deterministic(tmp_path):
+    dates = pd.date_range("2022-01-01", periods=800, freq="D")
+    df = pd.DataFrame({"close": np.linspace(100, 120, len(dates))}, index=dates)
+
+    report = walk_forward(
+        df,
+        make_strategy=lambda params: Flat(params),
+        params={},
+        train_years=1.0,
+        test_months=2.0,
+        step_months=2.0,
+        seed=123,
+        metric_fn=_metric_stub,
+        run_fn=_run_backtest_stub,
+    )
+
+    assert report["fold_count"] > 0
+    aggregate = json.dumps(report["aggregate"], sort_keys=True)
+    assert "return" in aggregate
+
+    # ensure folds round-trip to JSON cleanly
+    out_path = tmp_path / "wf.json"
+    out_path.write_text(json.dumps(report, sort_keys=True))
+    parsed = json.loads(out_path.read_text())
+    assert parsed["fold_count"] == report["fold_count"]


### PR DESCRIPTION
## Summary
- add a lightweight walk_forward helper and serialisable fold result to backtest.walkforward
- expose a new `wf` Click subcommand that resolves strategy factories, prepares CSV inputs and writes JSON reports
- cover the workflow with a deterministic unit test, README instructions, and a CI smoke step
- ensure the CI workflow installs the repository requirements so the walk-forward smoke step has access to click and other dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d3b4f0528c8320bfceb263eaaea319