### PR TITLE
feat(trinity+wf): Add TheTrinityEngine + walk-forward CLI + validator handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ python -m backtest.cli run \
 ### Walk-forward (expanding train → OOS test)
 
 ```bash
-python -m backtest.cli wf \
+python -m backtest.cli wf-json \
   --csv data/sample_multi_asset_data.csv \
   --strategy sma_cross \
   --params '{"fast": 10, "slow": 30}' \
@@ -91,6 +91,28 @@ python -m backtest.cli wf-opt \
 The report captures the best parameter set per fold along with out-of-sample metrics.
 Pass `--mode delta` and include `signal_mode=delta` in the grid if you prefer delta
 signals.
+
+### Walk-Forward (Trinity)
+
+```bash
+python -m backtest.cli wf \
+  --csv data/SPY.csv \
+  --grid "entropy_lookback=40 entry_entropy_threshold=0.015,0.02 breakout_period=55,70 ema_fast=21 ema_slow=100" \
+  --mode target --out-csv artifacts/wf_oos_returns.csv
+# Then summarize
+python -m backtest.cli metrics --csv artifacts/wf_oos_returns.csv
+```
+
+This command runs anchored folds (train → select → test) using the Trinity strategy,
+logging out-of-sample daily returns to `artifacts/wf_oos_returns.csv`.
+
+---
+
+### Validator handoff
+
+`strategy_validation_suite 2.py` (yep, that filename) can now ingest
+`artifacts/wf_oos_returns.csv` directly. The CSV exposes a `ret_oos` column with
+daily returns; if the consumer just expects "last column wins" it'll still work.
 
 See **[docs/system_diagram.md](docs/system_diagram.md)** for architecture and flow diagrams.
 

--- a/backtest/tests/test_wf_smoke.py
+++ b/backtest/tests/test_wf_smoke.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pandas as pd
+
+from backtest.core.engine import run_backtest
+from backtest.strategies.trinity import factory as make_trinity
+from backtest.walk_forward import walk_forward
+
+
+def test_walk_forward_generates_oos_returns(tmp_path):
+    rng = np.random.default_rng(7)
+    index = pd.date_range("2021-01-04", periods=520, freq="B")
+    prices = 100.0 * np.exp(np.cumsum(rng.normal(0.0, 0.01, len(index))))
+    frame = pd.DataFrame(
+        {
+            "close": prices,
+            "high": prices * 1.005,
+            "low": prices * 0.995,
+            "volume": np.full(len(index), 1_000_000),
+        },
+        index=index,
+    )
+
+    grid = [
+        {
+            "entropy_lookback": 20,
+            "entry_entropy_threshold": 0.5,
+            "breakout_period": 30,
+            "ema_fast": 10,
+            "ema_slow": 40,
+            "vwap_len": 10,
+        }
+    ]
+
+    oos = walk_forward(
+        frame,
+        make_trinity,
+        grid,
+        train_days=400,
+        test_days=100,
+        run_backtest=run_backtest,
+        mode="target",
+        sizing_kwargs={"size_notional": 10_000},
+        out_csv=tmp_path / "wf_oos.csv",
+    )
+
+    assert len(oos) >= 90
+    assert (tmp_path / "wf_oos.csv").exists()

--- a/backtest/walk_forward.py
+++ b/backtest/walk_forward.py
@@ -1,0 +1,170 @@
+"""Anchored walk-forward pipeline that emits out-of-sample returns."""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Sequence
+
+import numpy as np
+import pandas as pd
+
+StrategyFactory = Callable[[Dict[str, object]], object]
+RunBacktestFn = Callable[..., object]
+
+
+def _coerce(value: str) -> object:
+    value = value.strip()
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value
+
+
+def _parse_grid_token(token: str) -> tuple[str, List[object]]:
+    if "=" not in token:
+        raise ValueError(f"Malformed grid token: {token}")
+    name, raw_values = token.split("=", 1)
+    values = [segment.strip() for segment in raw_values.split(",") if segment.strip()]
+    if not values:
+        raise ValueError(f"No values supplied for grid parameter '{name}'")
+    return name.strip(), [_coerce(value) for value in values]
+
+
+def parse_grid(grid_str: str) -> List[Dict[str, object]]:
+    """Parse a simple CLI grid specification into parameter dictionaries."""
+
+    text = (grid_str or "").strip()
+    if not text:
+        return [{}]
+
+    pairs = [_parse_grid_token(token) for token in text.split()]
+    keys = [name for name, _ in pairs]
+    values = [choices for _, choices in pairs]
+    combos = [dict(zip(keys, combo)) for combo in itertools.product(*values)]
+    return combos or [{}]
+
+
+def _select_best_params(
+    frame: pd.DataFrame,
+    factory: StrategyFactory,
+    params_grid: Iterable[Dict[str, object]],
+    *,
+    run_backtest: RunBacktestFn,
+    mode: str,
+    sizing_kwargs: Dict[str, object],
+) -> Dict[str, object]:
+    best_params: Dict[str, object] | None = None
+    best_score = -np.inf
+    for params in params_grid:
+        strategy = factory(params)
+        result = run_backtest(frame, strategy, mode=mode, **sizing_kwargs)
+        equity_attr = getattr(result, "equity_curve", None)
+        if equity_attr is None:
+            raise AttributeError("run_backtest result must expose 'equity_curve'")
+        equity = pd.Series(equity_attr, dtype=float)
+        returns = equity.pct_change().dropna()
+        std = float(returns.std(ddof=0))
+        if std == 0:
+            if best_params is None:
+                best_params = dict(params)
+            continue
+        sharpe = float(returns.mean()) / std * np.sqrt(252.0)
+        if sharpe > best_score:
+            best_score = sharpe
+            best_params = dict(params)
+    if best_params is None:
+        raise RuntimeError("walk_forward: unable to find viable parameters")
+    return best_params
+
+
+def walk_forward(
+    data: pd.DataFrame,
+    strategy_factory: StrategyFactory,
+    param_grid: Sequence[Dict[str, object]],
+    *,
+    train_days: int = 500,
+    test_days: int = 125,
+    run_backtest: RunBacktestFn,
+    mode: str = "target",
+    sizing_kwargs: Dict[str, object] | None = None,
+    out_csv: str | Path = "artifacts/wf_oos_returns.csv",
+) -> pd.Series:
+    """Run anchored walk-forward analysis and return concatenated OOS returns."""
+
+    if train_days <= 0 or test_days <= 0:
+        raise ValueError("train_days and test_days must be positive")
+
+    frame = data.copy()
+    frame.index = pd.DatetimeIndex(frame.index)
+    grid = list(param_grid) or [{}]
+    sizing_kwargs = dict(sizing_kwargs or {})
+
+    oos_returns: list[pd.Series] = []
+    start = 0
+    while start + train_days + test_days <= len(frame):
+        train_slice = frame.iloc[start : start + train_days]
+        test_slice = frame.iloc[start + train_days : start + train_days + test_days]
+
+        best_params = _select_best_params(
+            train_slice,
+            strategy_factory,
+            grid,
+            run_backtest=run_backtest,
+            mode=mode,
+            sizing_kwargs=sizing_kwargs,
+        )
+
+        strategy = strategy_factory(best_params)
+        result = run_backtest(test_slice, strategy, mode=mode, **sizing_kwargs)
+        equity_attr = getattr(result, "equity_curve", None)
+        if equity_attr is None:
+            raise AttributeError("run_backtest result must expose 'equity_curve'")
+        equity = pd.Series(equity_attr, dtype=float)
+        returns = equity.pct_change().fillna(0.0)
+        returns.index.name = "date"
+        oos_returns.append(returns.rename("ret_oos"))
+
+        start += test_days
+
+    if not oos_returns:
+        raise RuntimeError("walk_forward: no folds were generated")
+
+    oos = pd.concat(oos_returns)
+    out_path = Path(out_csv)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    oos.to_csv(out_path)
+    return oos
+
+
+def run_wf_from_cli(
+    csv_path: str,
+    grid: str,
+    StrategyFactory: StrategyFactory,
+    run_backtest: RunBacktestFn,
+    *,
+    mode: str = "target",
+    train_days: int = 500,
+    test_days: int = 125,
+    out_csv: str = "artifacts/wf_oos_returns.csv",
+    sizing_kwargs: Dict[str, object] | None = None,
+) -> pd.Series:
+    """Helper invoked by the CLI to run the walk-forward pipeline."""
+
+    df = pd.read_csv(csv_path, parse_dates=[0], index_col=0)
+    df = df.rename(columns=lambda c: c.lower())
+    param_grid = parse_grid(grid)
+    return walk_forward(
+        df,
+        StrategyFactory,
+        param_grid,
+        train_days=train_days,
+        test_days=test_days,
+        run_backtest=run_backtest,
+        mode=mode,
+        sizing_kwargs=sizing_kwargs or {},
+        out_csv=out_csv,
+    )


### PR DESCRIPTION
## Summary
- add a lightweight walk-forward helper and CLI entry point that writes `ret_oos` CSVs for Trinity
- refresh the Trinity strategy to mirror the volatility/breakout/volume consensus used in C#
- expose a CLI metrics helper and documentation so validation scripts can consume the new artifacts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d4551640d883208bbcbfcb41942112