### PR TITLE
Add risk guardian, turbo gating, and sensitivity tool

### DIFF
--- a/backtest/cli.py
+++ b/backtest/cli.py
@@ -34,6 +34,14 @@ def cli():
 @click.option("--trades-csv", default=None)
 @click.option("--plot", is_flag=True)
 @click.option("--seed", type=int, default=None, help="Deterministic seed")
+@click.option(
+    "--maxR-per-day",
+    "maxR_per_day",
+    type=float,
+    default=3.0,
+    show_default=True,
+    help="Circuit breaker: block new entries once cumulative daily loss exceeds the limit (in R).",
+)
 def run_cmd(**kw):
     cli_run_backtest(**kw)
 

--- a/backtest/engines/__init__.py
+++ b/backtest/engines/__init__.py
@@ -1,5 +1,15 @@
 """Backtesting engines for CLI convenience."""
 
-from .multi_asset_backtest import run_backtest
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
 
 __all__ = ["run_backtest"]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - import side-effect glue
+    if name == "run_backtest":
+        module = import_module("backtest.engines.multi_asset_backtest")
+        return getattr(module, "run_backtest")
+    raise AttributeError(name)

--- a/backtest/engines/risk_guardian.py
+++ b/backtest/engines/risk_guardian.py
@@ -1,0 +1,42 @@
+"""Daily risk circuit breaker helper."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+import pandas as pd
+
+
+@dataclass
+class RiskGuardian:
+    """Tracks realised R per day and blocks new entries after a limit."""
+
+    maxR_per_day: float = 3.0
+    dayR: Dict[pd.Timestamp, float] = field(default_factory=dict)
+
+    def can_enter(self, timestamp: pd.Timestamp) -> bool:
+        """Return ``True`` if fresh exposure is still allowed on *timestamp*."""
+
+        day = pd.Timestamp(timestamp).normalize()
+        limit = -abs(float(self.maxR_per_day))
+        return self.dayR.get(day, 0.0) > limit
+
+    def on_trade_closed(
+        self, *, t_exit: pd.Timestamp, pnl: float, initial_risk_dollars: float
+    ) -> None:
+        """Record realised ``R`` for the day of *t_exit*.
+
+        ``initial_risk_dollars`` represents the original risk budget allocated
+        to the trade in dollars. When it is zero or negative the update is
+        ignored.
+        """
+
+        if initial_risk_dollars is None or initial_risk_dollars <= 0:
+            return
+        r_value = float(pnl) / float(initial_risk_dollars)
+        day = pd.Timestamp(t_exit).normalize()
+        self.dayR[day] = self.dayR.get(day, 0.0) + r_value
+
+
+__all__ = ["RiskGuardian"]

--- a/backtest/indicators/__init__.py
+++ b/backtest/indicators/__init__.py
@@ -1,0 +1,5 @@
+"""Indicator helpers used by bundled strategies."""
+
+from .patterns import nr7
+
+__all__ = ["nr7"]

--- a/backtest/indicators/patterns.py
+++ b/backtest/indicators/patterns.py
@@ -1,0 +1,25 @@
+"""Pattern recognition helpers."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def nr7(high: pd.Series, low: pd.Series, lookback: int = 7) -> pd.Series:
+    """Return a boolean series for the NR7 (narrowest range in ``lookback`` bars).
+
+    Parameters
+    ----------
+    high, low:
+        Series representing the high and low of each bar.
+    lookback:
+        Window length used to compare true ranges. The default mirrors the
+        canonical "NR7" setup.
+    """
+
+    true_range = (high - low).abs()
+    rolling_min = true_range.rolling(lookback, min_periods=lookback).min()
+    return (true_range <= rolling_min).fillna(False)
+
+
+__all__ = ["nr7"]

--- a/tools/sensitivity_entropy_breakout.py
+++ b/tools/sensitivity_entropy_breakout.py
@@ -1,0 +1,117 @@
+"""Generate a sensitivity heatmap for Praetorian entropy/breakout settings."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from backtest.core.data import (
+    ensure_datetime_index,
+    infer_periods_per_year,
+    require_columns,
+    standardize_columns,
+)
+from backtest.core.engine import run_backtest
+from backtest.strategies.praetorian import ThePraetorianEngine
+
+
+def _load_frame(path: Path) -> pd.DataFrame:
+    frame = pd.read_csv(path)
+    frame = standardize_columns(frame)
+    frame = ensure_datetime_index(frame)
+    require_columns(frame, ["close"])
+    if "high" not in frame.columns:
+        frame["high"] = frame["close"]
+    if "low" not in frame.columns:
+        frame["low"] = frame["close"]
+    if "volume" not in frame.columns:
+        frame["volume"] = 1.0
+    return frame
+
+
+def _compute_sharpe(equity: pd.Series) -> float:
+    returns = equity.pct_change().dropna()
+    if returns.empty:
+        return 0.0
+    periods = infer_periods_per_year(equity.index)
+    std = float(returns.std(ddof=0))
+    if std <= 0:
+        return 0.0
+    mean = float(returns.mean())
+    return float(mean / std * np.sqrt(periods))
+
+
+def run_sensitivity(frame: pd.DataFrame, out_path: Path) -> None:
+    ent_vals = [0.010, 0.012, 0.015, 0.018, 0.020]
+    brk_vals = [30, 40, 55, 70, 90]
+    z = np.zeros((len(ent_vals), len(brk_vals)))
+
+    for i, entropy_threshold in enumerate(ent_vals):
+        for j, breakout_period in enumerate(brk_vals):
+            params: Dict[str, object] = dict(
+                entropy_lookback=40,
+                entry_entropy_threshold=entropy_threshold,
+                breakout_period=breakout_period,
+                ema_fast=21,
+                ema_slow=100,
+                vwap_len=20,
+                vwap_max_distance_atr=1.0,
+                base_risk_percent=1.0,
+                turbo=1,
+                nr7=1,
+                conviction_gain=0.25,
+                conviction_loss=0.50,
+                min_conviction=0.5,
+                max_conviction=1.75,
+            )
+            strategy = ThePraetorianEngine(params)
+            result = run_backtest(
+                frame,
+                strategy,
+                mode="target",
+                atr_len=14,
+                risk_R=1.0,
+                risk_pct=0.01,
+                maxR_per_day=3.0,
+            )
+            z[i, j] = _compute_sharpe(result.equity_curve)
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    im = ax.imshow(z, cmap="viridis", origin="lower", aspect="auto")
+    ax.set_xticks(range(len(brk_vals)), brk_vals)
+    ax.set_yticks(range(len(ent_vals)), ent_vals)
+    ax.set_xlabel("Breakout Period (N)")
+    ax.set_ylabel("Entry Entropy Threshold")
+    ax.set_title("OOS Sharpe — Sensitivity (Entropy vs Breakout)")
+    cbar = fig.colorbar(im, ax=ax)
+    cbar.set_label("Sharpe")
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+    print(f"Saved {out_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--csv", required=True, help="Input OHLCV CSV")
+    parser.add_argument(
+        "--out",
+        default="artifacts/sensitivity_entropy_breakout.png",
+        help="Output image path",
+    )
+    args = parser.parse_args()
+
+    csv_path = Path(args.csv)
+    frame = _load_frame(csv_path)
+    out_path = Path(args.out)
+    run_sensitivity(frame, out_path)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    main()


### PR DESCRIPTION
## Summary
- add a reusable RiskGuardian helper and wire it into the core engine so fresh entries are blocked once the daily R cap is hit
- persist per-trade initial risk in the broker so realised R can be computed, and expose a CLI flag to configure the circuit breaker
- extend Praetorian/Trinity with NR7/turbo toggles via a shared indicator helper and add a sensitivity heatmap script for entropy/breakout sweeps

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4669c51688320a94da0f596aabd64