### PR TITLE
Add data fetch script and enhance engine tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ This lab ties together:
 
 > CI now generates a tiny deterministic sample at `data/sample_multi_asset_data.csv` so the examples run out-of-the-box.
 
+## Data Pipeline
+
+Fetch live data using the included script:
+
+```bash
+python scripts/fetch_data.py --symbols AAPL SPY QQQ --interval 1d --output data/
+```
+
+> Requires `yfinance` (`pip install yfinance`).
+
+## Licensing
+
+Default: MIT. Consider dual-licensing (e.g., MIT + Commercial) for IP protection (e.g., proof capsules). Consult a lawyer if needed.
+
 ### Deterministic quick-run
 
 ```bash

--- a/backtest/tests/test_engine.py
+++ b/backtest/tests/test_engine.py
@@ -14,3 +14,23 @@ def test_noop_equity_constant():
     df = pd.DataFrame({"close": 100.0}, index=idx)
     rr = run_backtest(df, Noop({}), starting_cash=10_000, mode="target")
     assert rr.equity_curve.iloc[0] == rr.equity_curve.iloc[-1]
+
+
+def test_engine_empty_data():
+    df = pd.DataFrame(columns=["close"], dtype=float)
+    result = run_backtest(df, Noop({}), starting_cash=5_000, mode="target")
+    assert result.equity_curve.empty
+    assert result.position_curve.empty
+
+
+def test_engine_high_entropy_scenario():
+    idx = pd.date_range("2024-01-02", periods=6, freq="B")
+    df = pd.DataFrame(
+        {
+            "close": [100, 50, 125, 60, 140, 80],
+        },
+        index=idx,
+    )
+    result = run_backtest(df, Noop({}), starting_cash=1_000, mode="target")
+    assert len(result.equity_curve) == len(df)
+    assert (result.equity_curve == 1_000).all()

--- a/scripts/fetch_data.py
+++ b/scripts/fetch_data.py
@@ -1,0 +1,83 @@
+"""Fetch historical price data for a list of symbols using yfinance."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+try:
+    import yfinance as yf
+except ImportError as exc:  # pragma: no cover - imported module should exist at runtime
+    raise SystemExit(
+        "yfinance is required to fetch data. Install it with 'pip install yfinance'."
+    ) from exc
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Download price history for symbols.")
+    parser.add_argument(
+        "--symbols",
+        nargs="+",
+        required=True,
+        help="One or more ticker symbols to download (e.g., AAPL SPY QQQ)",
+    )
+    parser.add_argument(
+        "--period",
+        default="1y",
+        help="Lookback period to request from yfinance (default: 1y)",
+    )
+    parser.add_argument(
+        "--interval",
+        default="1d",
+        help="Sampling interval (default: 1d). See yfinance docs for options.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data"),
+        help="Directory where the CSV files should be saved (default: data)",
+    )
+    parser.add_argument(
+        "--auto-adjust",
+        action="store_true",
+        help="Apply dividends/splits adjustments when downloading.",
+    )
+    return parser.parse_args(argv)
+
+
+def _write_symbol_data(symbol: str, df: pd.DataFrame, output_dir: Path) -> None:
+    if df.empty:
+        print(f"[warn] No data returned for {symbol}.", file=sys.stderr)
+        return
+
+    df = df.rename(columns=str.lower)
+    df.index.name = "datetime"
+    output_path = output_dir / f"{symbol}.csv"
+    df.to_csv(output_path)
+    print(f"[ok] Wrote {output_path}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    output_dir = args.output
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for symbol in args.symbols:
+        print(f"[info] Fetching {symbol}...")
+        data = yf.download(
+            symbol,
+            period=args.period,
+            interval=args.interval,
+            auto_adjust=args.auto_adjust,
+            progress=False,
+        )
+        _write_symbol_data(symbol, data, output_dir)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document a simple pipeline for fetching live data and note dual-licensing guidance
- add a yfinance-powered helper script for downloading OHLCV history into CSVs
- expand engine unit tests to cover empty datasets and volatile price series

## Testing
- `pytest backtest/tests/test_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68d4818af8ec8320b653ac51888c0d65