### PR TITLE
Document Alpha Breakout strategy integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ This lab ties together:
 - **C# / NinjaTrader components** (execution-grade sizers/strategies)
 - **Specs** (one manifest that maps roadmap → code → strategy)
 
+## Strategy Integration
+
+The `AlphaBreakoutEntropy_v1_1` strategy now ships alongside the other NinjaTrader components in `csharp/`. Sensitive helpers (for example, `AlphaBreakoutEntropyPrivateLogic.cs`) stay outside version control while the public entry point is referenced in `specs/manifest.json` for parameter exposure and coordination with the research stack.
+
 ### Data schemas (what the repo expects)
 
 **Single-asset (per-symbol) CSV** — used by loaders & validators in `data/`  

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple helper to compile the public C# strategies/sizers into a NinjaTrader-ready DLL.
+# Private logic files (e.g., AlphaBreakoutEntropyPrivateLogic.cs) are intentionally
+# excluded from public builds so they can be stored outside the repo.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CS_DIR="$ROOT_DIR/csharp"
+OUT_DIR="$CS_DIR/bin"
+DLL_NAME="EntropyPortfolioLab.dll"
+
+mkdir -p "$OUT_DIR"
+
+mapfile -d '' PUBLIC_SOURCES < <(find "$CS_DIR" -maxdepth 1 -name '*.cs' -not -name '*PrivateLogic.cs' -print0 | sort -z)
+
+if [[ ${#PUBLIC_SOURCES[@]} -eq 0 ]]; then
+  echo "No public C# sources found in $CS_DIR" >&2
+  exit 1
+fi
+
+if command -v mcs >/dev/null 2>&1; then
+  echo "Compiling public C# sources into $OUT_DIR/$DLL_NAME"
+  mcs -target:library -out:"$OUT_DIR/$DLL_NAME" "${PUBLIC_SOURCES[@]}"
+  echo "Build complete. Copy the DLL into your NinjaTrader bin/Custom folder as needed."
+else
+  echo "Mono C# compiler (mcs) not found. Install mono-devel or open the files in NinjaTrader/Visual Studio." >&2
+  exit 1
+fi

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -1,3 +1,18 @@
 # C# Components
 
 This directory holds the NinjaTrader / C# implementations that align with the Python backtesting toolkit. Drop in files like `MultiAssetPortfolioSizer.cs` and `AethelredAegis.cs` when you port the execution layer.
+
+## AlphaBreakoutEntropy_v1_1
+
+- `AlphaBreakoutEntropy_v1_1.cs` is the public entry point that wires the entropy breakout logic for NinjaTrader.
+- Keep any proprietary helpers (e.g., `AlphaBreakoutEntropyPrivateLogic.cs`) out of the repository or encrypted. The build tooling intentionally skips files matching `*PrivateLogic.cs` so private code never lands in public releases.
+
+## Building
+
+Use the repo-level helper to compile the public C# components into a DLL:
+
+```bash
+./build.sh
+```
+
+The script looks for `mcs` (Mono) and excludes private helpers by default. If you need to test with your private logic locally, copy the helper next to this directory before running the build or compile from within NinjaTrader/Visual Studio.

--- a/specs/manifest.json
+++ b/specs/manifest.json
@@ -22,6 +22,8 @@
   "csharp": {
     "sizer": "csharp/MultiAssetPortfolioSizer.cs",
     "strategy": "csharp/AethelredAegis.cs",
+    "execution": "csharp/AlphaBreakoutEntropy_v1_1.cs",
+    "private": "// Maintain proprietary helpers like AlphaBreakoutEntropyPrivateLogic.cs outside source control.",
     "alignment": "Mirror entropy thresholds & risk knobs between Python and C#."
   },
   "strategies": [
@@ -34,6 +36,19 @@
         "Multi-timeframe Confirmer"
       ],
       "target": "NinjaTrader live trading"
+    },
+    {
+      "name": "AlphaBreakoutEntropy_v1_1",
+      "type": "Alpha Breakout Entropy",
+      "modules": [
+        "AlphaBreakoutEntropy_v1_1"
+      ],
+      "target": "csharp",
+      "params": [
+        "entropy_lookback",
+        "breakout_period",
+        "risk_fraction"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a helper build script that compiles the public C# sources while omitting private logic
- document the AlphaBreakoutEntropy_v1_1 strategy integration in the root and C# READMEs
- extend the manifest with the new strategy metadata and an execution entry point reference

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d48d3c30b08320bdf1b2efc15cf027