### PR TITLE
Refactor private entropy hooks

### DIFF
--- a/csharp/AlphaBreakoutEntropyPrivateLogic.cs
+++ b/csharp/AlphaBreakoutEntropyPrivateLogic.cs
@@ -18,33 +18,30 @@ namespace NinjaTrader.NinjaScript.Strategies
             if (CurrentBar <= EntropyLookback)
                 return 0.0;
 
-            double sum = 0.0;
             int lookback = Math.Min(EntropyLookback, CurrentBar);
+            double[] returns = new double[lookback];
             for (int i = 0; i < lookback; i++)
             {
-                double diff = Close[i] - Close[i + 1];
-                sum += Math.Abs(diff);
+                returns[i] = Close[i] - Close[i + 1];
             }
 
-            return lookback > 0 ? sum / lookback : 0.0;
+            return PrivateLogic.CalculatePrivateEntropy(returns, lookback);
         }
 
         private void InitializePrivateResonance()
         {
-            // Placeholder hook for proprietary motif or resonance state.
+            PrivateLogic.InitializeResonance();
             lastEntropy = 0.0;
         }
 
         private bool IsPrivateEntryValid()
         {
-            // Placeholder gate that can be extended with private checks.
-            return true;
+            return PrivateLogic.IsEntryValid();
         }
 
         private bool IsPrivateExitValid()
         {
-            // Placeholder gate that can be extended with private checks.
-            return true;
+            return PrivateLogic.IsExitValid();
         }
     }
 }

--- a/csharp/PrivateLogic.cs
+++ b/csharp/PrivateLogic.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace NinjaTrader.NinjaScript.Strategies
+{
+    /// <summary>
+    /// Placeholder for proprietary entropy/resonance logic. Internal builds can
+    /// replace these implementations with sensitive calculations without
+    /// altering the public-facing strategy surface area.
+    /// </summary>
+    internal static class PrivateLogic
+    {
+        internal static double CalculatePrivateEntropy(double[] returns, int lookback)
+        {
+            if (returns == null || returns.Length == 0 || lookback <= 0)
+                return 0.0;
+
+            int effectiveLength = Math.Min(lookback, returns.Length);
+            double sum = 0.0;
+            for (int i = 0; i < effectiveLength; i++)
+                sum += Math.Abs(returns[i]);
+
+            return effectiveLength > 0 ? sum / effectiveLength : 0.0;
+        }
+
+        internal static void InitializeResonance()
+        {
+            // Placeholder hook for proprietary motif or resonance state.
+        }
+
+        internal static bool IsEntryValid()
+        {
+            // Placeholder gate that can be extended with private checks.
+            return true;
+        }
+
+        internal static bool IsExitValid()
+        {
+            // Placeholder gate that can be extended with private checks.
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- route AlphaBreakoutEntropy private helpers through a new `PrivateLogic` static class so internal builds can drop in proprietary code
- keep placeholder implementations that derive entropy inputs from the public strategy while calling the new extension points

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d48fbdc4d883209012f97edb79b8d1