### PR TITLE
Add walkforward and placebo runners

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -20,6 +20,10 @@ jobs:
         run: ruff check backtest || true
       - name: Type-check (best-effort)
         run: mypy backtest || true
+      - name: Walkforward test (smoke)
+        run: python scripts/run_walkforward.py --config configs/etrp.yml --train 3 --test 1 --out runs/walkforward_smoke.csv
+      - name: Placebo test (smoke)
+        run: python scripts/run_placebo.py --config configs/etrp.yml --mode shuffle_months --out runs/placebo_smoke.csv
       - name: Tests + coverage
         run: pytest -q --cov=backtest --cov-report=xml
       - name: Upload coverage

--- a/scripts/run_placebo.py
+++ b/scripts/run_placebo.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""
+Placebo test runner: scrambles returns to check strategy robustness.
+If strategy still prints god-mode Sharpe under placebo, you know it's lying.
+
+Usage:
+    python scripts/run_placebo.py --config configs/etrp.yml --mode shuffle_months
+"""
+from __future__ import annotations
+import argparse, sys, yaml
+from pathlib import Path
+import pandas as pd, numpy as np
+from copy import deepcopy
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+import lab.strategies as lab_strategies
+sys.modules.setdefault("strategies", lab_strategies)
+from lab.run import load_prices
+from lab.strategies.etrp import run_etrp
+
+def shuffle_months(px: pd.DataFrame, seed=42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    # group by month, shuffle the order
+    g = list(px.groupby(px.index.to_period("M")))
+    rng.shuffle(g)
+    df = pd.concat([grp for _, grp in g])
+    df.index = pd.date_range(start=px.index[0], periods=len(df), freq="B")
+    return df
+
+def permute_within_blocks(px: pd.DataFrame, block_days=21, seed=42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    idx = px.index
+    arr = px.values.copy()
+    n = len(idx)
+    for start in range(0, n, block_days):
+        block = arr[start:start+block_days]
+        rng.shuffle(block)
+        arr[start:start+block_days] = block
+    df = pd.DataFrame(arr, index=idx, columns=px.columns)
+    return df
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", default="configs/etrp.yml")
+    ap.add_argument("--mode", choices=["shuffle_months","permute_blocks"], default="shuffle_months")
+    ap.add_argument("--out", default="runs/placebo.csv")
+    args = ap.parse_args()
+
+    cfg = yaml.safe_load(open(args.config))
+
+    def load_prices_resilient(cfg: dict) -> pd.DataFrame:
+        try:
+            return load_prices(cfg)
+        except Exception as exc:
+            if cfg.get("data", {}).get("use_synth_if_missing", True):
+                print(f"[placebo] warning: {exc}. Falling back to synthetic data.")
+                cfg2 = deepcopy(cfg)
+                cfg2["data"]["data_dir"] = "__synthetic__"
+                return load_prices(cfg2)
+            raise
+
+    px = load_prices_resilient(cfg)
+
+    if args.mode == "shuffle_months":
+        px2 = shuffle_months(px)
+    else:
+        px2 = permute_within_blocks(px)
+
+    res = run_etrp(px2, cfg)
+    m = {k: float(v) for k,v in res["metrics"].items()}
+    df = pd.DataFrame([m])
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(args.out, index=False)
+    print(f"[placebo] saved {args.out}")
+    print(df)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_walkforward.py
+++ b/scripts/run_walkforward.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+"""
+Walk-forward backtest runner for Entropy-Portfolio-Lab.
+Splits history into rolling train/test folds, runs strategy, saves metrics per fold.
+
+Usage:
+    python scripts/run_walkforward.py --config configs/etrp.yml --train 5 --test 1
+"""
+from __future__ import annotations
+import argparse, sys, yaml
+from pathlib import Path
+from copy import deepcopy
+import pandas as pd
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+import lab.strategies as lab_strategies
+sys.modules.setdefault("strategies", lab_strategies)
+from lab.run import load_prices
+from lab.strategies.etrp import run_etrp
+
+def rolling_windows(start: pd.Timestamp, end: pd.Timestamp, train_years: int, test_years: int):
+    # month granularity
+    idx = pd.date_range(start, end, freq="M")
+    for i in range(0, len(idx) - (train_years + test_years)*12 + 1, test_years*12):
+        train_start = idx[i]
+        train_end   = idx[i + train_years*12 - 1]
+        test_start  = idx[i + train_years*12]
+        test_end    = idx[min(i + (train_years+test_years)*12 - 1, len(idx)-1)]
+        yield (train_start, train_end, test_start, test_end)
+
+def load_prices_resilient(cfg: dict):
+    try:
+        return load_prices(cfg)
+    except Exception as exc:
+        if cfg.get("data", {}).get("use_synth_if_missing", True):
+            print(f"[run_fold] warning: {exc}. Falling back to synthetic data.")
+            cfg2 = deepcopy(cfg)
+            cfg2["data"]["data_dir"] = "__synthetic__"
+            return load_prices(cfg2)
+        raise
+
+
+def run_fold(cfg: dict, start: pd.Timestamp, end: pd.Timestamp) -> dict:
+    cfg2 = deepcopy(cfg)
+    cfg2["backtest"]["start"] = str(start.date())
+    cfg2["backtest"]["end"]   = str(end.date())
+    px = load_prices_resilient(cfg2)
+    res = run_etrp(px, cfg2)
+    m = {k: float(v) for k,v in res["metrics"].items()}
+    m.update({"start": str(start.date()), "end": str(end.date())})
+    return m
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", default="configs/etrp.yml")
+    ap.add_argument("--train", type=int, default=5, help="train years")
+    ap.add_argument("--test", type=int, default=1, help="test years")
+    ap.add_argument("--out", default="runs/walkforward.csv")
+    args = ap.parse_args()
+
+    cfg = yaml.safe_load(open(args.config))
+    start = pd.Timestamp(cfg["backtest"]["start"])
+    end   = pd.Timestamp(cfg["backtest"]["end"])
+
+    rows = []
+    for tr_start, tr_end, te_start, te_end in rolling_windows(start, end, args.train, args.test):
+        # in a true hyperparam search you'd tune on train here; we just run test
+        print(f"[fold] train {tr_start.date()}→{tr_end.date()} | test {te_start.date()}→{te_end.date()}")
+        m = run_fold(cfg, te_start, te_end)
+        rows.append(m)
+
+    df = pd.DataFrame(rows)
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(args.out, index=False)
+    print(f"[walkforward] saved metrics to {args.out}")
+    print(df.describe().T)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add scripts for walk-forward backtests and placebo perturbations
- wire the new scripts into the python CI workflow for smoke coverage

## Testing
- python scripts/run_walkforward.py --config configs/etrp.yml --train 5 --test 1
- python scripts/run_placebo.py --config configs/etrp.yml --mode shuffle_months
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d4e57f4164832097de243d54d4d82c