### PR TITLE
Add packaging metadata and quickstart assets for EntropyLab

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,131 +1,25 @@
-# PolyForm Noncommercial License 1.0.0
+MIT License – Open-Source (Personal / Academic)
+Copyright (c) 2025 Derek Wins
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-## Acceptance
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-In order to get any license under these terms, you must agree
-to them as both strict obligations and conditions to all
-your licenses.
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
-## Copyright License
-
-The licensor grants you a copyright license for the
-software to do everything you might do with the software
-that would otherwise infringe the licensor's copyright
-in it for any permitted purpose.  However, you may
-only distribute the software according to [Distribution
-License](#distribution-license) and make changes or new works
-based on the software according to [Changes and New Works
-License](#changes-and-new-works-license).
-
-## Distribution License
-
-The licensor grants you an additional copyright license
-to distribute copies of the software.  Your license
-to distribute covers distributing the software with
-changes and new works permitted by [Changes and New Works
-License](#changes-and-new-works-license).
-
-## Notices
-
-You must ensure that anyone who gets a copy of any part of
-the software from you also gets a copy of these terms or the
-URL for them above, as well as copies of any plain-text lines
-beginning with `Required Notice:` that the licensor provided
-with the software.  For example:
-
-> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
-
-## Changes and New Works License
-
-The licensor grants you an additional copyright license to
-make changes and new works based on the software for any
-permitted purpose.
-
-## Patent License
-
-The licensor grants you a patent license for the software that
-covers patent claims the licensor can license, or becomes able
-to license, that you would infringe by using the software.
-
-## Noncommercial Purposes
-
-Any noncommercial purpose is a permitted purpose.
-
-## Personal Uses
-
-Personal use for research, experiment, and testing for
-the benefit of public knowledge, personal study, private
-entertainment, hobby projects, amateur pursuits, or religious
-observance, without any anticipated commercial application,
-is use for a permitted purpose.
-
-## Noncommercial Organizations
-
-Use by any charitable organization, educational institution,
-public research organization, public safety or health
-organization, environmental protection organization,
-or government institution is use for a permitted purpose
-regardless of the source of funding or obligations resulting
-from the funding.
-
-## Fair Use
-
-You may have "fair use" rights for the software under the
-law. These terms do not limit them.
-
-## No Other Rights
-
-These terms do not allow you to sublicense or transfer any of
-your licenses to anyone else, or prevent the licensor from
-granting licenses to anyone else.  These terms do not imply
-any other licenses.
-
-## Patent Defense
-
-If you make any written claim that the software infringes or
-contributes to infringement of any patent, your patent license
-for the software granted under these terms ends immediately. If
-your company makes such a claim, your patent license ends
-immediately for work on behalf of your company.
-
-## Violations
-
-The first time you are notified in writing that you have
-violated any of these terms, or done anything with the software
-not covered by your licenses, your licenses can nonetheless
-continue if you come into full compliance with these terms,
-and take practical steps to correct past violations, within
-32 days of receiving notice.  Otherwise, all your licenses
-end immediately.
-
-## No Liability
-
-***As far as the law allows, the software comes as is, without
-any warranty or condition, and the licensor will not be liable
-to you for any damages arising out of these terms or the use
-or nature of the software, under any kind of legal claim.***
-
-## Definitions
-
-The **licensor** is the individual or entity offering these
-terms, and the **software** is the software the licensor makes
-available under these terms.
-
-**You** refers to the individual or entity agreeing to these
-terms.
-
-**Your company** is any legal entity, sole proprietorship,
-or other kind of organization that you work for, plus all
-organizations that have control over, are under the control of,
-or are under common control with that organization.  **Control**
-means ownership of substantially all the assets of an entity,
-or the power to direct its management and policies by vote,
-contract, or otherwise.  Control can be direct or indirect.
-
-**Your licenses** are all the licenses granted to you for the
-software under these terms.
-
-**Use** means anything you do with the software requiring one
-of your licenses.
+COMMERCIAL LICENSE
+If you use EntropyLab in a for-profit entity or charge for access, you must buy a
+Commercial License at https://entropylab.co/pricing
+Contact: derekalexanderespinoza@gmail.com  for site-wide or multi-seat deals.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Entropy Portfolio Lab
+# EntropyLab ⚡  
+Turn market chaos into backtests in 13 seconds.  
+`pip install entropylab` → [Get Pro](https://entropylab.co)
+
+<!-- (Keep your existing README content below this line) -->
 
 <!-- ===== Project Badges ===== -->
 [![python-ci](https://github.com/derekwins88/Entropy-Portfolio-Lab/actions/workflows/ci-python.yml/badge.svg?branch=main)](https://github.com/derekwins88/Entropy-Portfolio-Lab/actions/workflows/ci-python.yml)
@@ -8,13 +12,13 @@
 
 ![Python 3.11](https://img.shields.io/badge/Python-3.11-3776AB?logo=python&logoColor=white)
 ![Node 20](https://img.shields.io/badge/Node-20-339933?logo=node.js&logoColor=white)
-[![License: Polyform Noncommercial](https://img.shields.io/badge/License-Polyform%20NC-blue.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](.github/CONTRIBUTING.md)
 [![Last commit](https://img.shields.io/github/last-commit/derekwins88/Entropy-Portfolio-Lab.svg)](https://github.com/derekwins88/Entropy-Portfolio-Lab/commits/main)
 
 > A unified, research-to-execution sandbox for **entropy-aware portfolio trading**.
 
-Licensing: personal and academic use is free under **Polyform Noncommercial 1.0.0**. **Commercial or for-profit use requires a paid license** — see [`LICENSES/COMMERCIAL.md`](LICENSES/COMMERCIAL.md).
+Licensing: personal and academic use is free under the MIT-based open-source terms. **Commercial or for-profit use requires a paid license** — see [`LICENSE`](LICENSE).
 
 ## Features
 - Entropy-tilted strategies (risk parity, momentum overlays)
@@ -62,6 +66,10 @@ Licensing: personal and academic use is free under **Polyform Noncommercial 1.0.
 PRs welcome for research workflows. Commercial users must obtain a license (see below). Please follow the existing CI workflows and keep strategy docs synced with ADRs.
 
 ## License
-- **Personal / academic:** Polyform Noncommercial 1.0.0 (see [`LICENSE`](LICENSE))
-- **Commercial / for-profit:** Contact for a paid license (see [`LICENSES/COMMERCIAL.md`](LICENSES/COMMERCIAL.md))
-- SPDX header recommendation: `SPDX-License-Identifier: Polyform-Noncommercial-1.0.0`
+- **Personal / academic:** MIT License – Open-Source (Personal / Academic) (see [`LICENSE`](LICENSE))
+- **Commercial / for-profit:** Purchase a Commercial License at https://entropylab.co/pricing or email derekalexanderespinoza@gmail.com
+- SPDX header recommendation: `SPDX-License-Identifier: MIT`
+
+## Commercial Use
+See [LICENSE](LICENSE).  
+Pro upgrade removes watermark & adds live-broker plugins.

--- a/entropylab/__init__.py
+++ b/entropylab/__init__.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+def backtest(prices, risk_free=0.0):
+    rets = prices.pct_change().dropna()
+    sharpe = ((rets.mean() - risk_free/252) / rets.std()) * (252 ** 0.5) if rets.std() else 0.0
+    print(f"Sharpe (entropylab): {sharpe:.2f}")
+    return {"sharpe": float(sharpe)}

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -1,0 +1,91 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# EntropyLab Quickstart ⚡\n",
+    "Backtest SPY in under a minute. If `entropylab` is installed, we’ll use it; otherwise we’ll run a tiny fallback to demonstrate the flow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, subprocess, importlib\n",
+    "def pip_install(pkg):\n",
+    "    subprocess.check_call([sys.executable, '-m', 'pip', 'install', pkg])\n",
+    "\n",
+    "try:\n",
+    "    import yfinance as yf\n",
+    "except Exception:\n",
+    "    pip_install('yfinance>=0.2.40')\n",
+    "    import yfinance as yf\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from datetime import datetime\n",
+    "\n",
+    "start = '2020-01-01'\n",
+    "end = '2020-12-31'\n",
+    "spy = yf.download('SPY', start=start, end=end, auto_adjust=True)\n",
+    "prices = spy['Close'].dropna()\n",
+    "prices.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fallback_backtest(prices: pd.Series, risk_free=0.0):\n",
+    "    rets = prices.pct_change().dropna()\n",
+    "    if rets.std() == 0:\n",
+    "        sharpe = 0.0\n",
+    "    else:\n",
+    "        sharpe = ((rets.mean() - risk_free/252) / rets.std()) * np.sqrt(252)\n",
+    "    nav = (1 + rets).cumprod()\n",
+    "    print(f\"Sharpe (fallback): {sharpe:.2f}\")\n",
+    "    return {\n",
+    "        'sharpe': float(sharpe),\n",
+    "        'final_return': float(nav.iloc[-1] - 1)\n",
+    "    }\n",
+    "\n",
+    "try:\n",
+    "    entropylab = importlib.import_module('entropylab')\n",
+    "    if hasattr(entropylab, 'backtest'):\n",
+    "        result = entropylab.backtest(prices)  # expected to print/return Sharpe\n",
+    "        print('Sharpe (entropylab):', getattr(result, 'sharpe', result))\n",
+    "    else:\n",
+    "        result = fallback_backtest(prices)\n",
+    "except Exception as e:\n",
+    "    print('[Info] entropylab not found or backtest() missing, using fallback.')\n",
+    "    result = fallback_backtest(prices)\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 🚀 Want to plug this into Interactive Brokers automatically?  \n",
+    "**Upgrade to EntropyLab Pro ($299 one-time)** → https://entropylab.co"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='entropylab',
+    version='1.0.0',
+    author='Derek Wins',
+    author_email='derekalexanderespinoza@gmail.com',
+    description='Entropy-powered backtesting engine',
+    long_description=open('README.md', encoding='utf-8').read(),
+    long_description_content_type='text/markdown',
+    url='https://github.com/derekwins88/entropylab',
+    packages=find_packages(exclude=("tests", "docs", "examples")),
+    install_requires=['pandas', 'numpy', 'matplotlib'],
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+    ],
+    python_requires='>=3.8',
+)


### PR DESCRIPTION
## Summary
- replace the PolyForm Noncommercial terms with the new MIT + commercial notice and update the README hero section and licensing details
- add setuptools packaging metadata and a minimal `entropylab.backtest` helper to support quick installs
- include an examples/quickstart notebook that downloads SPY data and exercises the package or a fallback Sharpe calculator

## Testing
- python -m build

------
https://chatgpt.com/codex/tasks/task_e_68df185e54c48320ad59de3250dfa6f8